### PR TITLE
PL 10 expose css artifact

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 .babelrc
 docs
 node_modules/
-build/
 .idea/
 coverage/

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ node_modules/
 .idea/
 coverage/
 src/scss
+.travis.yml

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ docs
 node_modules/
 .idea/
 coverage/
+src/scss

--- a/README.md
+++ b/README.md
@@ -13,19 +13,16 @@ community.
   - this will start the chat widget on localhost:9000
 
 ## Usage
-####Note:
+#### Note:
 this is still very much in development, but we're trying to keep the documentation up to date
 
-###Build
+### Build
 The widget is still in it's infancy and there are some warts we inherited from the Sendbird team. In order to bundle the widget
 with another project, the following must occur
 - the widget has been implemented into other projects systems using the [webpack module bundler](https://webpack.js.org/)
-  - therefore, it's assumed that if you're trying to include the widget you're using that bundler
-- because the widget uses SASS for it's stying, you must configure the [sass-loader](https://github.com/webpack-contrib/sass-loader)
-to load the widget's styling
 - the widget must be transpiled via [babel](https://github.com/babel/babel)
 
-###Incorporation
+### Incorporation
 To incorporate the widget, the following code must be written in a React project
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "onshift-chat-widget",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "onshift-chat-widget",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "onshift-chat-widget",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onshift-chat-widget",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "A chat widget based on and utilizing SendBird.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "description": "A chat widget based on and utilizing SendBird.",
   "main": "index.js",
   "scripts": {
-    "prod-build": "webpack -p",
-    "start-dev": "webpack-dev-server",
+    "prod-build": "npm run build-stylesheet && webpack -p",
+    "start-dev": "npm run build-stylesheet && webpack-dev-server",
     "test": "jest",
     "coverage": "jest --coverage",
-    "start": "webpack -p && node test_server/server.js",
-    "lint": "eslint src/"
+    "start": "npm run build-stylesheet && webpack -p && node test_server/server.js",
+    "lint": "eslint src/",
+    "build-stylesheet": "node-sass src/scss/widget.scss stylesheet.css"
   },
   "jest": {
     "testEnvironment": "node"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onshift-chat-widget",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A chat widget based on and utilizing SendBird.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "coverage": "jest --coverage",
     "start": "npm run build-stylesheet && webpack -p && node test_server/server.js",
     "lint": "eslint src/",
-    "build-stylesheet": "node-sass src/scss/widget.scss stylesheet.css"
+    "build-stylesheet": "node-sass src/scss/widget.scss build/stylesheet.css"
   },
   "jest": {
     "testEnvironment": "node"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onshift-chat-widget",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A chat widget based on and utilizing SendBird.",
   "main": "index.js",
   "scripts": {

--- a/src/js/elements/elements.js
+++ b/src/js/elements/elements.js
@@ -1,4 +1,3 @@
-import '../../scss/widget.scss';
 import { removeClass, addClass } from '../utils.js';
 import { className, styleValue } from '../consts.js';
 

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -1,5 +1,5 @@
 'use strict';
-import '../../stylesheet.css';
+import '../../build/stylesheet.css';
 import ChatSection from './elements/chat-section.js';
 import ListBoard from './elements/list-board.js';
 import Popup from './elements/popup.js';

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -1,5 +1,5 @@
 'use strict';
-
+import '../../stylesheet.css';
 import ChatSection from './elements/chat-section.js';
 import ListBoard from './elements/list-board.js';
 import Popup from './elements/popup.js';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,17 +18,14 @@ module.exports = {
     },
     module: {
         rules: [
-            { // SCSS
-                test: /\.scss$/,
+            {
+                test: /\.css$/,
                 use: [
                     {
                         loader: 'style-loader'
                     },
                     {
                         loader: 'css-loader'
-                    },
-                    {
-                        loader: 'sass-loader'
                     }
                 ]
             },


### PR DESCRIPTION
# Things Done
- utilize `node-sass` to compile SASS to CSS 
  - publish the CSS file, ignore the SASS
  - for development, simply alter the SASS file(s) and run any of the commands that recompile the CSS
- move style import to a more central location
- update README
- remove SASS loader in webpack config
- publish and bump version

# How To Test
- bad boy should still run and look the way it was before

# Related PRs
- [engage](https://github.com/samsawan/engage/pull/4)
- [kangaroo](https://github.com/gregsvo/kangaroo/pull/10)