### PR TITLE
PL 55 load up all users

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ node_modules/
 coverage/
 src/scss
 .travis.yml
+__test__

--- a/__test__/__mocks__/styleMock.js
+++ b/__test__/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/__test__/elements.test.js
+++ b/__test__/elements.test.js
@@ -1,0 +1,8 @@
+import Element from '../src/js/elements/elements';
+
+describe('new', () => {
+    test('can be instantiated', () => {
+        let element = new Element();
+        expect(element).toBeTruthy;
+    });
+});

--- a/__test__/elements.test.js
+++ b/__test__/elements.test.js
@@ -73,3 +73,9 @@ describe('_setClass', () => {
         expect(div.className).toBe('someclass anotherclass');
     });
 });
+
+test('setContent', () => {
+    let div = testElement.createDiv();
+    testElement._setContent(div, 'some content');
+    expect(div.innerHTML).toBe('some content');
+});

--- a/__test__/elements.test.js
+++ b/__test__/elements.test.js
@@ -1,8 +1,60 @@
 import Element from '../src/js/elements/elements';
 
+let testElement = new Element();
+
 describe('new', () => {
     test('can be instantiated', () => {
-        let element = new Element();
-        expect(element).toBeTruthy;
+        expect(testElement).toBeInstanceOf(Element);
+    });
+
+    test('it sets all of its tag types correctly', () => {
+        expect(testElement.tagType.A).toBe('a');
+        expect(testElement.tagType.DIV).toBe('div');
+        expect(testElement.tagType.SPAN).toBe('span');
+        expect(testElement.tagType.UL).toBe('ul');
+        expect(testElement.tagType.LI).toBe('li');
+        expect(testElement.tagType.TIME).toBe('time');
+        expect(testElement.tagType.LABEL).toBe('label');
+        expect(testElement.tagType.IMG).toBe('img');
+        expect(testElement.tagType.VIDEO).toBe('video');
+    });
+
+    test('it sets all of its events correctly', () => {
+        expect(testElement.eventName.CLICK).toBe('click');
+        expect(testElement.eventName.KEYDOWN).toBe('keydown');
+        expect(testElement.eventName.KEYUP).toBe('keyup');
+        expect(testElement.eventName.CHANGE).toBe('change');
+        expect(testElement.eventName.SCROLL).toBe('scroll');
+        expect(testElement.eventName.PASTE).toBe('paste');
+    });
+});
+
+describe('HTML element creation tests', () => {
+    test('div', () => {
+        expect(testElement.createDiv()).toBeInstanceOf(HTMLDivElement);
+    });
+    test('time', () => {
+        expect(testElement.createTime()).toBeInstanceOf(HTMLTimeElement);
+    });
+    test('anchor', () => {
+        expect(testElement.createA()).toBeInstanceOf(HTMLAnchorElement);
+    });
+    test('image', () => {
+        expect(testElement.createImg()).toBeInstanceOf(HTMLImageElement);
+    });
+    test('span', () => {
+        expect(testElement.createSpan()).toBeInstanceOf(HTMLSpanElement);
+    });
+    test('label', () => {
+        expect(testElement.createLabel()).toBeInstanceOf(HTMLLabelElement);
+    });
+    test('input', () => {
+        expect(testElement.createInput()).toBeInstanceOf(HTMLInputElement);
+    });
+    test('ul', () => {
+        expect(testElement.createUl()).toBeInstanceOf(HTMLUListElement);
+    });
+    test('li', () => {
+        expect(testElement.createLi()).toBeInstanceOf(HTMLLIElement);
     });
 });

--- a/__test__/elements.test.js
+++ b/__test__/elements.test.js
@@ -58,3 +58,18 @@ describe('HTML element creation tests', () => {
         expect(testElement.createLi()).toBeInstanceOf(HTMLLIElement);
     });
 });
+
+describe('_setClass', () => {
+
+    test('can handle one class', () => {
+        let div = testElement.createDiv();
+        testElement._setClass(div, ['someclass']);
+        expect(div.className).toBe('someclass');
+    });
+
+    test('can multiple one classes', () => {
+        let div = testElement.createDiv();
+        testElement._setClass(div, ['someclass','anotherclass']);
+        expect(div.className).toBe('someclass anotherclass');
+    });
+});

--- a/__test__/utils.test.js
+++ b/__test__/utils.test.js
@@ -1,5 +1,5 @@
 import * as utils from '../src/js/utils';
-import {ANIMATION_EVENT, ANIMATION_REGEX, DISPLAY_NONE, DISPLAY_BLOCK} from '../src/js/consts';
+import {ANIMATION_EVENT, DISPLAY_NONE, DISPLAY_BLOCK} from '../src/js/consts';
 
 function buildDummyTarget(specs) {
     let target = document.createElement('div');

--- a/__test__/widget.test.js
+++ b/__test__/widget.test.js
@@ -4,3 +4,11 @@ test('the widget can be instantiated', () => {
     let widget = new SBWidget();
     expect(widget).toBeTruthy
 });
+
+describe('_init', () => {
+    // let widget = new SBWidget();
+    test('initializes the components we need', () => {
+        // widget._init();
+        true;
+    });
+});

--- a/__test__/widget.test.js
+++ b/__test__/widget.test.js
@@ -1,4 +1,10 @@
 import SBWidget from '../src/js/widget';
+import Element from '../src/js/elements/elements';
+import WidgetBtn from '../src/js/elements/widget-btn';
+import Spinner from '../src/js/elements/spinner';
+import Popup from '../src/js/elements/popup';
+import ListBoard from '../src/js/elements/list-board';
+import ChatSection from '../src/js/elements/chat-section';
 
 test('the widget can be instantiated', () => {
     let widget = new SBWidget();
@@ -6,9 +12,20 @@ test('the widget can be instantiated', () => {
 });
 
 describe('_init', () => {
-    // let widget = new SBWidget();
-    test('initializes the components we need', () => {
-        // widget._init();
-        true;
+    let widget = new SBWidget();
+    widget.widget = new Element().createDiv();
+    widget._init();
+
+    test('initializes the elelments needed for a functional chat widget', () => {
+        expect(widget.widgetBtn).toBeInstanceOf(WidgetBtn);
+        expect(widget.popup).toBeInstanceOf(Popup);
+        expect(widget.spinner).toBeInstanceOf(Spinner);
+        expect(widget.listBoard).toBeInstanceOf(ListBoard);
+        expect(widget.chatSection).toBeInstanceOf(ChatSection);
+    });
+
+    test('initializes member variables to sane empty states', () => {
+        expect(widget.activeChannelSetList).toEqual([]);
+        expect(widget.extraChannelSetList).toEqual([]);
     });
 });

--- a/__test__/widget.test.js
+++ b/__test__/widget.test.js
@@ -1,0 +1,6 @@
+import SBWidget from '../src/js/widget';
+
+test('the widget can be instantiated', () => {
+    let widget = new SBWidget();
+    expect(widget).toBeTruthy
+});

--- a/__test__/widget.test.js
+++ b/__test__/widget.test.js
@@ -2,7 +2,7 @@ import SBWidget from '../src/js/widget';
 
 test('the widget can be instantiated', () => {
     let widget = new SBWidget();
-    expect(widget).toBeTruthy
+    expect(widget).toBeInstanceOf(SBWidget);
 });
 
 describe('_init', () => {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
   },
   "jest": {
     "testEnvironment": "jsdom",
-    "verbose": true
+    "verbose": true,
+    "moduleNameMapper": {
+      "\\.(css|less)$": "<rootDir>/__test__/__mocks__/styleMock.js"
+    }
   },
   "author": "OnShift",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "testEnvironment": "jsdom",
     "verbose": true,
     "moduleNameMapper": {
-      "\\.(css|less)$": "<rootDir>/__test__/__mocks__/styleMock.js"
+      ".css": "<rootDir>/__test__/__mocks__/styleMock.js"
     }
   },
   "author": "OnShift",

--- a/src/js/elements/chat-section.js
+++ b/src/js/elements/chat-section.js
@@ -606,14 +606,6 @@ class ChatSection extends Element {
         return this._isBottom(targetContent, targetList);
     }
 
-    addUserListScrollEvent(target, action) {
-        this._setScrollEvent(target.userContent, () => {
-            if (this.isBottom(target.userContent, target.userContent.list)) {
-                action();
-            }
-        });
-    }
-
     scrollToBottom(target) {
         target.scrollTop = target.scrollHeight - target.clientHeight;
     }

--- a/src/js/elements/elements.js
+++ b/src/js/elements/elements.js
@@ -100,10 +100,6 @@ class Element {
         target.style.width = `${width}px`;
     }
 
-    _setRight(target, right) {
-        target.style.right = `${right}px`;
-    }
-
     _setDataset(target, name, data) {
         target.setAttribute(`data-${name}`, data);
     }

--- a/src/js/elements/popup.js
+++ b/src/js/elements/popup.js
@@ -169,14 +169,6 @@ class Popup extends Element {
         });
     }
 
-    addScrollEvent(action) {
-        this._setScrollEvent(this.invitePopup.content, () => {
-            if (this._isBottom(this.invitePopup.content, this.invitePopup.list)) {
-                action();
-            }
-        });
-    }
-
     addClickEvent(target, action) {
         this._setClickEvent(target, action);
     }

--- a/src/js/elements/widget-btn.js
+++ b/src/js/elements/widget-btn.js
@@ -9,11 +9,6 @@ class WidgetBtn extends Element {
         widget.appendChild(this.self);
     }
 
-    reset() {
-        this.toggleIcon(false);
-        this.setUnreadCount(0);
-    }
-
     _create() {
         this.self = this.createDiv();
         this._setClass(this.self, [className.WIDGET_BTN, className.IC_LOGIN]);

--- a/src/js/sendbird-wrapper.js
+++ b/src/js/sendbird-wrapper.js
@@ -147,12 +147,12 @@ class SendBirdWrapper {
 
     /*User*/
 
-    getUserList(action) {
+    getUserList(action, iterations = 1) {
         if (!this.userListQuery) {
             this.userListQuery = this.sb.createUserListQuery();
             this.userListQuery.limit = 100;
         }
-        if (this.userListQuery.hasNext && !this.userListQuery.isLoading) {
+        if (this.userListQuery.hasNext && !this.userListQuery.isLoading && iterations <= 10) {
             this.userListQuery.next((userList, error) => {
                 if (error) {
                     console.error(error);

--- a/src/js/sendbird-wrapper.js
+++ b/src/js/sendbird-wrapper.js
@@ -152,7 +152,7 @@ class SendBirdWrapper {
             this.userListQuery = this.sb.createUserListQuery();
             this.userListQuery.limit = 100;
         }
-        if (this.userListQuery.hasNext && !this.userListQuery.isLoading && iterations <= 10) {
+        if (this.userListQuery.hasNext && !this.userListQuery.isLoading && iterations <= 5) {
             this.userListQuery.next((userList, error) => {
                 if (error) {
                     console.error(error);

--- a/src/js/sendbird-wrapper.js
+++ b/src/js/sendbird-wrapper.js
@@ -150,6 +150,7 @@ class SendBirdWrapper {
     getUserList(action) {
         if (!this.userListQuery) {
             this.userListQuery = this.sb.createUserListQuery();
+            this.userListQuery.limit = 100;
         }
         if (this.userListQuery.hasNext && !this.userListQuery.isLoading) {
             this.userListQuery.next((userList, error) => {

--- a/src/js/sendbird-wrapper.js
+++ b/src/js/sendbird-wrapper.js
@@ -147,7 +147,7 @@ class SendBirdWrapper {
 
     /*User*/
 
-    getUserList(action, iterations = 1) {
+    getUserList(action, iterations) {
         if (!this.userListQuery) {
             this.userListQuery = this.sb.createUserListQuery();
             this.userListQuery.limit = 100;

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -592,12 +592,12 @@ class SBWidget {
         });
     }
 
-    loadUsersForInviteList(memberIds, removeSpinner = true) {
+    loadUsersForInviteList(memberIds) {
         let iterations = 0;
-        let loadUsers = (spinner) => {
+        let loadUsers = (removeSpinner) => {
             iterations += 1;
             this.sb.getUserList((userList) => {
-                if (spinner) {
+                if (removeSpinner) {
                     this.spinner.remove(this.popup.invitePopup.list);
                 }
                 for (let i = 0 ; i < userList.length ; i++) {
@@ -616,7 +616,7 @@ class SBWidget {
                 loadUsers(false);
             }, iterations);
         };
-        loadUsers(removeSpinner);
+        loadUsers(true);
     }
 
     updateChannelInfo(target, channel) {

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -203,10 +203,18 @@ class SBWidget {
             });
             this.spinner.insert(chatBoard.userContent);
 
-            this.sb.getUserList((userList) => {
-                this.spinner.remove(chatBoard.userContent);
-                this.setUserList(chatBoard, userList);
-            });
+            let iterations = 0;
+            let _getUserList = (removeSpinner) => {
+                iterations += 1;
+                this.sb.getUserList((userList) => {
+                    if(removeSpinner) {
+                        this.spinner.remove(chatBoard.userContent);
+                    }
+                    this.setUserList(chatBoard, userList);
+                    _getUserList(false);
+                }, iterations);
+            };
+            _getUserList(true);
 
             this.chatSection.addClickEvent(chatBoard.closeBtn, () => {
                 this.chatSection.closeChatBoard(chatBoard);

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -436,12 +436,6 @@ class SBWidget {
                 userContent.list.appendChild(item);
             }
         }
-
-        this.chatSection.addUserListScrollEvent(target, () => {
-            this.sb.getUserList((userList) => {
-                this.setUserList(target, userList);
-            });
-        });
     }
 
     getChannelList() {

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -578,9 +578,6 @@ class SBWidget {
                     return member.userId;
                 });
                 this.loadUsersForInviteList(memberIds);
-                this.popup.addScrollEvent(() => {
-                    this.loadUsersForInviteList(memberIds, false);
-                });
             }
         });
         this.spinner.insert(chatBoard.content);

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -593,7 +593,7 @@ class SBWidget {
     }
 
     loadUsersForInviteList(memberIds, removeSpinner = true) {
-        let iterations = 1;
+        let iterations = 0;
         let loadUsers = (spinner) => {
             iterations += 1;
             this.sb.getUserList((userList) => {

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -125,7 +125,7 @@ class SBWidget {
         let protocol = 'https:' === document.location.protocol ? 'https' : 'http';
         wf.src = `${protocol}://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js`;
         wf.type = 'text/javascript';
-        wf.async = 'true';
+        wf.async = true;
         let s = document.getElementsByTagName('script')[0];
         s.parentNode.insertBefore(wf, s);
     }

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -537,7 +537,9 @@ class SBWidget {
             }
         });
         this.chatSection.addClickEvent(chatBoard.inviteBtn, () => {
+            let iterations = 1;
             let _getUserList = (memberIds, loadmore) => {
+                iterations += 1;
                 this.sb.getUserList((userList) => {
                     if (!loadmore) {
                         this.spinner.remove(this.popup.invitePopup.list);
@@ -555,7 +557,8 @@ class SBWidget {
                             this.popup.invitePopup.list.appendChild(item);
                         }
                     }
-                });
+                    _getUserList(memberIds, true);
+                }, iterations);
             };
             this.popup.addClickEvent(this.popup.invitePopup.inviteBtn, () => {
                 if (!hasClass(this.popup.invitePopup.inviteBtn, className.DISABLED)) {


### PR DESCRIPTION
# Things Done
- load up 500 users, immediately, when trying to invite members to a chat
- load up 500 users, immediately, when trying to create a new chat
- remove scroll events
  - can no longer scroll to bottom of any invite list and load up more users
  - bad UX
- refactor code to allow for DRY alphabetizing in next card

# How To Test
- spin up the widget
- look at how many people are being loaded when you either
  - start a new chat
  - invite users to an existing chat
