### PR TITLE
PL 31 remove unread message counts

### DIFF
--- a/__test__/sendbird.test.js
+++ b/__test__/sendbird.test.js
@@ -39,7 +39,6 @@ describe('attachHandlers', () => {
             messageDeletedHandler: (a, b) => { state = a * b; },
             channelChangedHandler: (a) => { state = a; },
             typingStatusHandler: (a) => { state = -a; },
-            readReceiptHandler: (a) => { state = a * a; },
             userLeftHandler: (a, b) => { state = b - a; },
             userJoinedHandler: (a, b) => { state = b / a; },
         };
@@ -55,8 +54,6 @@ describe('attachHandlers', () => {
         expect(state).toEqual(firstNum);
         handlerContainer.onTypingStatusUpdated(firstNum);
         expect(state).toEqual(-firstNum);
-        handlerContainer.onReadReceiptUpdated(firstNum);
-        expect(state).toEqual(firstNum * firstNum);
         handlerContainer.onUserLeft(firstNum, secondNum);
         expect(state).toEqual(secondNum - firstNum);
         handlerContainer.onUserJoined(firstNum, secondNum);

--- a/src/js/elements/chat-section.js
+++ b/src/js/elements/chat-section.js
@@ -1,4 +1,4 @@
-import { className, MAX_COUNT } from '../consts.js';
+import { className } from '../consts.js';
 import Element from './elements.js';
 import {
   show,
@@ -11,7 +11,6 @@ import {
 const CHAT_SECTION_RIGHT_MAX = '-20px';
 const CHAT_SECTION_RIGHT_MIN = '60px';
 const DISPLAY_NONE = 'none';
-const DISPLAY_TYPE_INLINE_BLOCK = 'inline-block';
 const EMPTY_STRING = '';
 const IMAGE_MAX_SIZE = 160;
 const MARGIN_TOP_MESSAGE = '3px';
@@ -364,7 +363,7 @@ class ChatSection extends Element {
         }
     }
 
-    createMessageItem(message, isCurrentUser, isContinue, unreadCount) {
+    createMessageItem(message, isCurrentUser, isContinue) {
         let messageSet = this.createDiv();
         messageSet.id = message.messageId;
         this._setClass(messageSet, isCurrentUser ? [className.MESSAGE_SET, className.USER] : [className.MESSAGE_SET]);
@@ -488,7 +487,6 @@ class ChatSection extends Element {
 
         let itemUnread = this.createDiv();
         this._setClass(itemUnread, [className.UNREAD]);
-        this.setUnreadCount(itemUnread, unreadCount);
         messageSet.unread = itemUnread;
 
         if (isCurrentUser) {
@@ -502,30 +500,6 @@ class ChatSection extends Element {
         messageContent.appendChild(messageItem);
         messageSet.appendChild(messageContent);
         return messageSet;
-    }
-
-    setUnreadCount(target, count) {
-        count = parseInt(count);
-        let renderSingleDigitCount = (c) => {
-            return c === 0 ? '' : c.toString();
-        };
-        let text = count > 9 ? MAX_COUNT : renderSingleDigitCount(count);
-        this._setContent(target, text);
-        count > 0 ? show(target, DISPLAY_TYPE_INLINE_BLOCK) : hide(target);
-    }
-
-    updateReadReceipt(channelSet, target) {
-        let items = target.querySelectorAll(`.${  className.MESSAGE_SET}`);
-        for (let j = 0; j < channelSet.message.length; j++) {
-            let message = channelSet.message[j];
-            for (let i = 0; i < items.length; i++) {
-                let item = items[i];
-                if (item.id === message.messageId) {
-                    this.setUnreadCount(item.unread, channelSet.channel.getReadReceipt(message));
-                    break;
-                }
-            }
-        }
     }
 
     createMessageItemTime(date) {

--- a/src/js/sendbird-wrapper.js
+++ b/src/js/sendbird-wrapper.js
@@ -186,9 +186,6 @@ class SendBirdWrapper {
         handler.onTypingStatusUpdated = function (channel) {
             handlerSpecs.typingStatusHandler(channel);
         };
-        handler.onReadReceiptUpdated = function (channel) {
-            handlerSpecs.readReceiptHandler(channel);
-        };
         handler.onUserLeft = function (channel, user) {
             handlerSpecs.userLeftHandler(channel, user);
         };

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -735,8 +735,7 @@ class SBWidget {
             } else if (!message.isAdminMessage()) {
                 let isContinue = prevMessage && prevMessage.sender ? message.sender.userId === prevMessage.sender.userId : false;
                 let isCurrentUser = this.sb.isCurrentUser(message.sender);
-                let unreadCount = channel.getReadReceipt(message);
-                newMessage = this.chatSection.createMessageItem(message, isCurrentUser, isContinue, unreadCount);
+                newMessage = this.chatSection.createMessageItem(message, isCurrentUser, isContinue);
                 insertMessageIntoBoard(newMessage);
                 prevMessage = message;
             }

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -272,16 +272,6 @@ class SBWidget {
                         }
                     }
                 },
-                readReceiptHandler: (channel) => {
-                    let channelUrl = channel.url;
-                    let targetBoard = this.chatSection.getChatBoard(channelUrl);
-                    if (targetBoard) {
-                        let channelSet = this.getChannelSet(channelUrl);
-                        if (channelSet) {
-                            this.chatSection.updateReadReceipt(channelSet, targetBoard);
-                        }
-                    }
-                },
                 userLeftHandler: (channel, user) => {
                     let channelUrl = channel.url;
                     let listBoard = this.listBoard;

--- a/src/scss/widget.scss
+++ b/src/scss/widget.scss
@@ -1049,17 +1049,6 @@
             }
           }
         }
-        .unread {
-          @include reset();
-          display: none !important;
-          background-color: transparent;
-          color: $color-read-receipt;
-          font-size: 11px;
-          font-weight: 700;
-          text-align: center;
-          margin: 0 4px;
-          vertical-align: bottom;
-        }
       }
     }
     .message-set.user {
@@ -1083,9 +1072,6 @@
           margin: 0;
           @include imageMessage();
           @include border-radius(5px);
-        }
-        .unread {
-          display: inline-block !important;
         }
       }
     }


### PR DESCRIPTION
# Things Done
- remove unread message count from the left side of all chat areas
- remove all styling associated with it

# How To Test
- spin up the widget, see that no bubbles appear next to chats
- other unread message notifications (ie the red bubble on the widget button itself) still exist and are styled appropriately
