### PR TITLE
Stop nulling the ULQ prematurely

### DIFF
--- a/src/js/sendbird-wrapper.js
+++ b/src/js/sendbird-wrapper.js
@@ -156,10 +156,13 @@ class SendBirdWrapper {
             this.userListQuery.next((userList, error) => {
                 if (error) {
                     console.error(error);
+                    this.userListQuery = null;
                     return;
                 }
                 action(userList);
             });
+        } else {
+            this.userListQuery = null;
         }
     }
 

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -481,7 +481,6 @@ class SBWidget {
     closeInvitePopup() {
         this.chatSection.removeInvitePopup();
         this.popup.closeInvitePopup();
-        this.sb.userListQuery = null;
     }
 
     _connectChannel(channelUrl, doNotCall) {


### PR DESCRIPTION
# Things Done
- due to the recursive nature by which we load the users, we need to maintain the ULQ _even after the popup clear event is fired_
- we still want to clear the ULQ if we run out of users to render, hence the addition of the `else` logic (and the error handling)

# How To Test
- load up users on an app with less than 100 people (like ours)!
- no duplicate users