### PR TITLE
PL 37 Build Changes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
   "presets": ["es2015"],
-  "plugins": ["transform-runtime"]
+  "plugins": ["transform-runtime"],
+  "minified": true
 }

--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,6 @@ docs
 node_modules/
 .idea/
 coverage/
-src/scss
+src
 .travis.yml
 __test__

--- a/index.html
+++ b/index.html
@@ -25,5 +25,9 @@
   </body>
 
   <script src="build/widget.SendBird.js"></script>
+  <script>
+    var sb = new window.onshiftChatWidget.default();
+    sb.start('9DA1B1F4-0BE6-4DA8-82C5-2E81DAB56F23');
+  </script>
 
 </html>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A chat widget based on and utilizing SendBird.",
   "main": "index.js",
   "scripts": {
+    "prepublish": "npm run prod-build",
     "prod-build": "npm run build-stylesheet && webpack -p",
     "start-dev": "npm run build-stylesheet && webpack-dev-server",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start-dev": "npm run build-stylesheet && webpack-dev-server",
     "test": "jest",
     "coverage": "jest --coverage",
-    "start": "npm run build-stylesheet && webpack -p && node test_server/server.js",
+    "start": "npm run build-stylesheet && webpack --env.local=true -p && node test_server/server.js",
     "lint": "eslint src/",
     "build-stylesheet": "node-sass src/scss/widget.scss build/stylesheet.css"
   },

--- a/src/js/mount.js
+++ b/src/js/mount.js
@@ -1,4 +1,0 @@
-import SBWidget from './widget';
-
-let sb = new SBWidget();
-sb.start('9DA1B1F4-0BE6-4DA8-82C5-2E81DAB56F23');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,59 +1,76 @@
 let path = require('path');
 
-module.exports = {
-    context: path.resolve(__dirname + '/src'),
-    entry: { widget: ['./js/mount.js'] },
-    output:
-    {
+function determineOutput(env) {
+    let config = {
         path: path.resolve(__dirname + '/build'),
         filename: '[name].SendBird.js',
-        publicPath: "build"
-    },
-    devtool: "cheap-eval-source-map",
-    devServer:
-    {
-        publicPath: '/build/',
-        compress: true,
-        port: 9000
-    },
-    module: {
-        rules: [
-            {
-                test: /\.css$/,
-                use: [
-                    {
-                        loader: 'style-loader'
-                    },
-                    {
-                        loader: 'css-loader'
-                    }
-                ]
-            },
-            { // ESLint
-                enforce: 'pre',
-                test: /\.js$/,
-                exclude: /(node_modules|SendBird.min.js)/,
-                use: [
-                    {
-                        loader: 'eslint-loader',
+        publicPath: 'build',
+        library: 'onshiftChatWidget',
+    };
+    if (env && env.local) {
+        config.libraryTarget = 'var';
+    } else {
+        config.libraryTarget = 'umd';
+        config.umdNamedDefine = true;
+    }
+    return config;
+}
+
+function determineConfig(env){
+    return {
+        context: path.resolve(__dirname + '/src'),
+        entry: { widget: ['./js/widget.js'] },
+        output: determineOutput(env),
+        devtool: "cheap-eval-source-map",
+        devServer:
+        {
+            publicPath: '/build/',
+            compress: true,
+            port: 9000
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.css$/,
+                    use: [
+                        {
+                            loader: 'style-loader'
+                        },
+                        {
+                            loader: 'css-loader'
+                        }
+                    ]
+                },
+                { // ESLint
+                    enforce: 'pre',
+                    test: /\.js$/,
+                    exclude: /(node_modules|SendBird.min.js)/,
+                    use: [
+                        {
+                            loader: 'eslint-loader',
+                            options:
+                            {
+                                failOnError: true
+                            }
+                        }
+                    ]
+                },
+                { // ES6
+                    test: /\.js$/,
+                    exclude: /(node_modules)/,
+                    use: {
+                        loader: 'babel-loader',
                         options:
                         {
-                            failOnError: true
+                            presets: ['env', 'es2015']
                         }
                     }
-                ]
-            },
-            { // ES6
-                test: /\.js$/,
-                exclude: /(node_modules)/,
-                use: {
-                    loader: 'babel-loader',
-                    options:
-                    {
-                        presets: ['env', 'es2015']
-                    }
                 }
-            }
-        ]
-    }
+            ]
+        }
+    };
+}
+
+module.exports = env => {
+    return determineConfig(env);
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,19 +1,19 @@
 let path = require('path');
 
 function determineOutput(env) {
-    let config = {
+    let output = {
         path: path.resolve(__dirname + '/build'),
         filename: '[name].SendBird.js',
         publicPath: 'build',
         library: 'onshiftChatWidget',
     };
     if (env && env.local) {
-        config.libraryTarget = 'var';
+        output.libraryTarget = 'var';
     } else {
-        config.libraryTarget = 'umd';
-        config.umdNamedDefine = true;
+        output.libraryTarget = 'umd';
+        output.umdNamedDefine = true;
     }
-    return config;
+    return output;
 }
 
 function determineConfig(env){


### PR DESCRIPTION
# Things Done
- removed `mount.js`
  - rendered the code unreusable (coupled with the existing webpack config) 
- building widget as a library
  - if locally (see `start` script in package.json), pass in variable that instructs webpack to attach widget to global window object
  - any other way, simply publish the package and allow it to be consumed via any module dependency manager in the usual ways
- add `prepublish` command so that the correct artifact is always published
- no longer publish untranspiled js to NPM

# How To Test
- `npm start` should still work
