### PR TITLE
PL 50 channel list pic

### DIFF
--- a/src/js/consts.js
+++ b/src/js/consts.js
@@ -93,6 +93,8 @@ export const styleValue = {
     CURSOR_INIT: ''
 };
 
+export const DEFAULT_PROFILE_PIC = 'https://dxstmhyqfqr1o.cloudfront.net/widget/thumnail-member-01.svg';
+
 export const MAX_COUNT = '+9';
 export const MAX_FONT_SIZE = '11';
 export const TYPE_STRING = 'string';

--- a/src/js/elements/list-board.js
+++ b/src/js/elements/list-board.js
@@ -1,7 +1,8 @@
 import {
     className,
     MAX_COUNT,
-    MAX_FONT_SIZE
+    MAX_FONT_SIZE,
+    DEFAULT_PROFILE_PIC
 } from '../consts.js';
 import {
     show,
@@ -197,7 +198,7 @@ class ListBoard extends Element {
         this._setClass(item, [className.ITEM]);
         let itemImg = this.createDiv();
         this._setClass(itemImg, [className.IMAGE]);
-        this._setBackgroundImage(itemImg, channelData.coverUrl);
+        this._setBackgroundImage(itemImg, DEFAULT_PROFILE_PIC);
         item.appendChild(itemImg);
 
         let itemContent = this.createDiv();


### PR DESCRIPTION
# Things Done
- display the user's 'default pic' when showing channel list

# How To Test
- spin up widget
- the picture next to the channels should mirror the picture next to the users in a given chat
