### PR TITLE
PL 68 No more setting cookies in widget

### DIFF
--- a/__test__/utils.test.js
+++ b/__test__/utils.test.js
@@ -140,24 +140,3 @@ describe('getFullHeight', () => {
         expect(utils.getFullHeight(target)).toEqual(4);
     });
 });
-
-describe('cookie manipulation', () => {
-    beforeEach(() => {
-        expect(document.cookie).toBeFalsy;
-    });
-
-    test('setCookie: sets the cookie to some values', () => {
-        let userId = 'userId';
-        let nickname = 'nickname';
-        utils.setCookie(userId, nickname);
-        expect(document.cookie).toBeTruthy();
-    });
-    test('getCookie: gets sb specific cookie info', () => {
-        let userId = 'userId';
-        let nickname = 'nickname';
-        utils.setCookie(userId, nickname);
-        let sbInfo = utils.getCookie();
-        expect(sbInfo.userId).toBe(userId);
-        expect(sbInfo.nickname).toBe(nickname);
-    });
-});

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
         possibleNames.push('widget_test_user_' + i);
       }
       name = possibleNames[Math.floor(Math.random() * Math.floor(limit))];
+      document.cookie = `sendbirdUserId=${name}`;
     }
     document.getElementById("currentUser").innerText = 'LOGGED IN AS: ' + name;
     var sb = new window.onshiftChatWidget.default();

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -114,34 +114,3 @@ export function requestNotification() {
         });
     }
 }
-
-export function setCookie(userId, nickname) {
-    let date = new Date();
-    date.setDate(date.getDate() + 1);
-    let expires = date.toGMTString();
-    document.cookie = `sendbirdUserId=${userId};expires=${expires}`;
-    document.cookie = `sendbirdNickname=${nickname};expires=${expires}`;
-}
-
-export function getCookie() {
-    let sendbirdUserInfo = {
-        'userId': '',
-        'nickname': ''
-    };
-    let cUserId = 'sendbirdUserId=';
-    let cNickname = 'sendbirdNickname=';
-    let cList = document.cookie.split(';');
-    for (let i = 0 ; i < cList.length ; i++) {
-        let c = cList[i];
-        while(c.charAt(0) === ' ') {
-            c = c.substring(1);
-        }
-        if (c.indexOf(cUserId) === 0) {
-            sendbirdUserInfo['userId'] = c.substring(cUserId.length, c.length);
-        }
-        else if (c.indexOf(cNickname) === 0) {
-            sendbirdUserInfo['nickname'] = c.substring(cNickname.length, c.length);
-        }
-    }
-    return sendbirdUserInfo;
-}

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -8,7 +8,6 @@ import Spinner from './elements/spinner.js';
 import WidgetBtn from './elements/widget-btn.js';
 import {
     addClass,
-    getCookie,
     getFullHeight,
     getLastItem,
     hasClass,
@@ -17,7 +16,6 @@ import {
     isEmptyString,
     removeClass,
     requestNotification,
-    setCookie,
     show,
     xssEscape
 } from './utils.js';
@@ -202,7 +200,6 @@ class SBWidget {
                 this.listBoard.userId.disabled = true;
                 this.listBoard.nickname.disabled = true;
                 this._connect(this.listBoard.getUserId(), this.listBoard.getNickname());
-                setCookie(this.listBoard.getUserId(), this.listBoard.getNickname());
             }
         });
         this.listBoard.addKeyDownEvent(this.listBoard.nickname, (event) => {
@@ -210,14 +207,6 @@ class SBWidget {
                 this.listBoard.btnLogin.click();
             }
         });
-
-        const cookie = getCookie();
-        if (cookie.userId) {
-            this._connect(cookie.userId, cookie.nickname);
-            this.listBoard.showChannelList();
-            this.toggleBoard(true);
-            this.responsiveChatSection.bind(this);
-        }
     }
 
     loadUsersForChatboard(chatBoard) {
@@ -237,7 +226,6 @@ class SBWidget {
 
     _connect(userId, nickname, accessToken) {
         this.sb.connect(userId, nickname, accessToken, () => {
-            setCookie(userId, nickname);
             this.widgetBtn.toggleIcon(true);
             this.listBoard.showChannelList();
             this.spinner.insert(this.listBoard.list);


### PR DESCRIPTION
# Things Done
- removed cookie reading/writing in widget 
  - all user persistence is now handled by the consumer 
- locally the index.html deal with user persistence

# How To Test
- no behavioral changes locally
- spin this up with engage (and maybe kangaroo one day) and ensure the widget isn't creating a cookie it then reads and attempts to reconnect to the sb instance with
