### PR TITLE
PL 83 fix stylings

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         possibleNames.push('a_widget_user_' + i);
       }
       userId = possibleNames[Math.floor(Math.random() * Math.floor(limit))];
-      document.cookie = `sendbirdUserId=${name}`;
+      document.cookie = `sendbirdUserId=${userId}`;
     }
     document.getElementById("currentUser").innerText = 'LOGGED IN AS: ' + userId;
     var sb = new window.onshiftChatWidget.default();

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
     },
     "acorn-dynamic-import": {
       "version": "2.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "dev": true,
       "requires": {
@@ -100,7 +100,7 @@
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/acorn/-/acorn-4.0.13.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
           "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
           "dev": true
         }
@@ -117,7 +117,7 @@
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
@@ -126,7 +126,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -134,12 +134,12 @@
     },
     "agentkeepalive": {
       "version": "2.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
       "integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8="
     },
     "ajv": {
       "version": "4.11.8",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/ajv/-/ajv-4.11.8.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
@@ -149,13 +149,13 @@
     },
     "ajv-keywords": {
       "version": "1.5.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
     },
     "align-text": {
       "version": "0.1.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/align-text/-/align-text-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
@@ -166,19 +166,19 @@
     },
     "alphanum-sort": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
     "amdefine": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/amdefine/-/amdefine-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
@@ -190,13 +190,13 @@
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
@@ -227,7 +227,7 @@
     },
     "are-we-there-yet": {
       "version": "1.1.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
@@ -246,7 +246,7 @@
     },
     "arr-diff": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/arr-diff/-/arr-diff-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
@@ -261,7 +261,7 @@
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
@@ -273,13 +273,13 @@
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
@@ -295,7 +295,7 @@
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
@@ -304,25 +304,25 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
       "version": "0.2.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/array-unique/-/array-unique-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1": {
       "version": "0.2.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/asn1/-/asn1-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
       "dev": true
     },
@@ -339,7 +339,7 @@
     },
     "assert": {
       "version": "1.4.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/assert/-/assert-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
       "dev": true,
       "requires": {
@@ -348,13 +348,13 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
@@ -375,13 +375,13 @@
     },
     "async-each": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/async-each/-/async-each-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
     "async-foreach": {
       "version": "0.1.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/async-foreach/-/async-foreach-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
       "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
       "dev": true
     },
@@ -393,7 +393,7 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
@@ -404,7 +404,7 @@
     },
     "autoprefixer": {
       "version": "6.7.7",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/autoprefixer/-/autoprefixer-6.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
       "dev": true,
       "requires": {
@@ -418,7 +418,7 @@
       "dependencies": {
         "browserslist": {
           "version": "1.7.7",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/browserslist/-/browserslist-1.7.7.tgz",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
@@ -430,7 +430,7 @@
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
@@ -442,7 +442,7 @@
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
@@ -480,7 +480,7 @@
     },
     "babel-eslint": {
       "version": "7.2.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-eslint/-/babel-eslint-7.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
       "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
       "dev": true,
       "requires": {
@@ -508,7 +508,7 @@
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
@@ -519,7 +519,7 @@
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
@@ -531,7 +531,7 @@
     },
     "babel-helper-define-map": {
       "version": "6.26.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
@@ -543,7 +543,7 @@
     },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
@@ -554,7 +554,7 @@
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
@@ -567,7 +567,7 @@
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
@@ -577,7 +577,7 @@
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
@@ -587,7 +587,7 @@
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
@@ -597,7 +597,7 @@
     },
     "babel-helper-regex": {
       "version": "6.26.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
@@ -608,7 +608,7 @@
     },
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
@@ -621,7 +621,7 @@
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
@@ -635,7 +635,7 @@
     },
     "babel-helpers": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
@@ -655,7 +655,7 @@
     },
     "babel-loader": {
       "version": "6.4.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-loader/-/babel-loader-6.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
       "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
       "dev": true,
       "requires": {
@@ -667,7 +667,7 @@
     },
     "babel-messages": {
       "version": "6.23.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-messages/-/babel-messages-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
@@ -676,7 +676,7 @@
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
@@ -713,13 +713,13 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
@@ -731,13 +731,13 @@
     },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
       "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
       "dev": true
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
@@ -748,7 +748,7 @@
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
@@ -757,7 +757,7 @@
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
@@ -766,7 +766,7 @@
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.26.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
@@ -779,7 +779,7 @@
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
@@ -796,7 +796,7 @@
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
@@ -806,7 +806,7 @@
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
@@ -815,7 +815,7 @@
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
@@ -825,7 +825,7 @@
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
@@ -834,7 +834,7 @@
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
@@ -845,7 +845,7 @@
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
@@ -854,7 +854,7 @@
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
@@ -877,7 +877,7 @@
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
@@ -888,7 +888,7 @@
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
@@ -899,7 +899,7 @@
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
@@ -909,7 +909,7 @@
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
@@ -923,7 +923,7 @@
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
@@ -933,7 +933,7 @@
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
@@ -942,7 +942,7 @@
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
@@ -953,7 +953,7 @@
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
@@ -962,7 +962,7 @@
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
@@ -971,7 +971,7 @@
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
@@ -982,7 +982,7 @@
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
@@ -993,7 +993,7 @@
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
@@ -1002,7 +1002,7 @@
     },
     "babel-plugin-transform-runtime": {
       "version": "6.15.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.15.0.tgz",
       "integrity": "sha1-PXW02Umtga8VdXAnOEb7Wa6w1Xw=",
       "dev": true,
       "requires": {
@@ -1011,7 +1011,7 @@
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
@@ -1059,7 +1059,7 @@
     },
     "babel-preset-es2015": {
       "version": "6.24.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "dev": true,
       "requires": {
@@ -1101,7 +1101,7 @@
     },
     "babel-register": {
       "version": "6.26.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-register/-/babel-register-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
@@ -1116,7 +1116,7 @@
     },
     "babel-runtime": {
       "version": "6.26.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
@@ -1126,7 +1126,7 @@
     },
     "babel-template": {
       "version": "6.26.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-template/-/babel-template-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
@@ -1139,7 +1139,7 @@
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
@@ -1156,7 +1156,7 @@
     },
     "babel-types": {
       "version": "6.26.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/babel-types/-/babel-types-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
@@ -1174,7 +1174,7 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
@@ -1207,7 +1207,7 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
       "optional": true,
@@ -1234,13 +1234,13 @@
     },
     "binary-extensions": {
       "version": "1.11.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
     "block-stream": {
       "version": "0.0.9",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/block-stream/-/block-stream-0.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
@@ -1261,7 +1261,7 @@
     },
     "body-parser": {
       "version": "1.18.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/body-parser/-/body-parser-1.18.2.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "dev": true,
       "requires": {
@@ -1301,7 +1301,7 @@
     },
     "boom": {
       "version": "4.3.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/boom/-/boom-4.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
@@ -1320,7 +1320,7 @@
     },
     "braces": {
       "version": "1.8.5",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/braces/-/braces-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
@@ -1331,7 +1331,7 @@
     },
     "brorand": {
       "version": "1.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/brorand/-/brorand-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
@@ -1396,7 +1396,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -1406,7 +1406,7 @@
     },
     "browserify-sign": {
       "version": "4.0.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
@@ -1449,7 +1449,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -1466,25 +1466,25 @@
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
     "bytes": {
       "version": "3.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/bytes/-/bytes-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
@@ -1507,7 +1507,7 @@
     },
     "caller-path": {
       "version": "0.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/caller-path/-/caller-path-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
@@ -1516,7 +1516,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -1528,7 +1528,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -1538,7 +1538,7 @@
     },
     "caniuse-api": {
       "version": "1.6.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/caniuse-api/-/caniuse-api-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "dev": true,
       "requires": {
@@ -1550,7 +1550,7 @@
       "dependencies": {
         "browserslist": {
           "version": "1.7.7",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/browserslist/-/browserslist-1.7.7.tgz",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
@@ -1574,13 +1574,13 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "center-align": {
       "version": "0.1.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/center-align/-/center-align-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
@@ -1598,7 +1598,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -1745,7 +1745,7 @@
     },
     "cli-cursor": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
@@ -1754,7 +1754,7 @@
     },
     "cli-width": {
       "version": "2.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/cli-width/-/cli-width-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
@@ -1789,13 +1789,13 @@
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/co/-/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "coa": {
       "version": "1.0.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/coa/-/coa-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "dev": true,
       "requires": {
@@ -1804,13 +1804,13 @@
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
@@ -1820,7 +1820,7 @@
     },
     "color": {
       "version": "0.11.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/color/-/color-0.11.4.tgz",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "dev": true,
       "requires": {
@@ -1840,13 +1840,13 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "color-string": {
       "version": "0.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/color-string/-/color-string-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "dev": true,
       "requires": {
@@ -1855,7 +1855,7 @@
     },
     "colormin": {
       "version": "1.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/colormin/-/colormin-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
       "dev": true,
       "requires": {
@@ -1866,13 +1866,13 @@
     },
     "colors": {
       "version": "1.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/colors/-/colors-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
     "combined-stream": {
       "version": "1.0.6",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/combined-stream/-/combined-stream-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
         "delayed-stream": "1.0.0"
@@ -1886,7 +1886,7 @@
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/commondir/-/commondir-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
@@ -1898,7 +1898,7 @@
     },
     "component-emitter": {
       "version": "1.2.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/component-emitter/-/component-emitter-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
     },
@@ -1936,7 +1936,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
@@ -1959,7 +1959,7 @@
     },
     "console-browserify": {
       "version": "1.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/console-browserify/-/console-browserify-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
@@ -1968,19 +1968,19 @@
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
     "content-disposition": {
       "version": "0.5.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/content-disposition/-/content-disposition-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
       "dev": true
     },
@@ -1998,25 +1998,25 @@
     },
     "convert-source-map": {
       "version": "1.5.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
       "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
       "dev": true
     },
     "cookie": {
       "version": "0.3.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/cookie/-/cookie-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
@@ -2028,7 +2028,7 @@
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
@@ -2080,7 +2080,7 @@
     },
     "cryptiles": {
       "version": "3.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/cryptiles/-/cryptiles-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
@@ -2119,13 +2119,13 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
     "css-loader": {
       "version": "0.27.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/css-loader/-/css-loader-0.27.3.tgz",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.27.3.tgz",
       "integrity": "sha1-aatvR7ab+xtazuYbrCqrFDAv8Nw=",
       "dev": true,
       "requires": {
@@ -2145,7 +2145,7 @@
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/loader-utils/-/loader-utils-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
@@ -2158,7 +2158,7 @@
     },
     "css-selector-tokenizer": {
       "version": "0.7.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
       "dev": true,
       "requires": {
@@ -2169,7 +2169,7 @@
       "dependencies": {
         "regexpu-core": {
           "version": "1.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/regexpu-core/-/regexpu-core-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "dev": true,
           "requires": {
@@ -2190,13 +2190,13 @@
     },
     "cssesc": {
       "version": "0.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/cssesc/-/cssesc-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
       "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
       "dev": true
     },
     "cssnano": {
       "version": "3.10.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/cssnano/-/cssnano-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
       "dev": true,
       "requires": {
@@ -2236,7 +2236,7 @@
     },
     "csso": {
       "version": "2.3.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/csso/-/csso-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
       "dev": true,
       "requires": {
@@ -2261,7 +2261,7 @@
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
@@ -2270,7 +2270,7 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/d/-/d-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
@@ -2279,7 +2279,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -2288,7 +2288,7 @@
     },
     "date-now": {
       "version": "0.1.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/date-now/-/date-now-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
@@ -2302,13 +2302,13 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
@@ -2320,7 +2320,7 @@
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
@@ -2346,7 +2346,7 @@
     },
     "define-properties": {
       "version": "1.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/define-properties/-/define-properties-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
@@ -2365,13 +2365,13 @@
     },
     "defined": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/defined/-/defined-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
     "del": {
       "version": "2.2.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/del/-/del-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
@@ -2386,24 +2386,24 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/delegates/-/delegates-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
     "des.js": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/des.js/-/des.js-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
@@ -2413,13 +2413,13 @@
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
     "detect-indent": {
       "version": "4.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/detect-indent/-/detect-indent-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
@@ -2512,7 +2512,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
       "optional": true,
@@ -2522,7 +2522,7 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
@@ -2540,7 +2540,7 @@
     },
     "elliptic": {
       "version": "6.4.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/elliptic/-/elliptic-6.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
@@ -2555,19 +2555,19 @@
     },
     "emojis-list": {
       "version": "2.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/emojis-list/-/emojis-list-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "enhanced-resolve": {
       "version": "3.4.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "dev": true,
       "requires": {
@@ -2588,7 +2588,7 @@
     },
     "error-ex": {
       "version": "1.3.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/error-ex/-/error-ex-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
@@ -2610,7 +2610,7 @@
     },
     "es-to-primitive": {
       "version": "1.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
@@ -2631,7 +2631,7 @@
     },
     "es6-iterator": {
       "version": "2.0.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
@@ -2642,7 +2642,7 @@
     },
     "es6-map": {
       "version": "0.1.5",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/es6-map/-/es6-map-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
@@ -2656,7 +2656,7 @@
     },
     "es6-set": {
       "version": "0.1.5",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/es6-set/-/es6-set-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
@@ -2669,7 +2669,7 @@
     },
     "es6-symbol": {
       "version": "3.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
@@ -2679,7 +2679,7 @@
     },
     "es6-weak-map": {
       "version": "2.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
@@ -2691,13 +2691,13 @@
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
@@ -2731,7 +2731,7 @@
     },
     "escope": {
       "version": "3.6.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/escope/-/escope-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
@@ -2743,7 +2743,7 @@
     },
     "eslint": {
       "version": "3.19.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/eslint/-/eslint-3.19.0.tgz",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
       "requires": {
@@ -2822,7 +2822,7 @@
     },
     "esprima": {
       "version": "2.7.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/esprima/-/esprima-2.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
       "dev": true
     },
@@ -2847,25 +2847,25 @@
     },
     "estraverse": {
       "version": "4.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/estraverse/-/estraverse-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/esutils/-/esutils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "event-emitter": {
       "version": "0.3.5",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/event-emitter/-/event-emitter-0.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
@@ -2881,7 +2881,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
@@ -2949,13 +2949,13 @@
     },
     "exit-hook": {
       "version": "1.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/exit-hook/-/exit-hook-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
@@ -2964,7 +2964,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -3036,7 +3036,7 @@
     },
     "extend": {
       "version": "3.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/extend/-/extend-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
@@ -3051,7 +3051,7 @@
     },
     "extglob": {
       "version": "0.3.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/extglob/-/extglob-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
@@ -3060,7 +3060,7 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
@@ -3072,19 +3072,19 @@
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fastparse": {
       "version": "1.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/fastparse/-/fastparse-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
       "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
       "dev": true
     },
@@ -3108,7 +3108,7 @@
     },
     "figures": {
       "version": "1.7.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/figures/-/figures-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
@@ -3118,7 +3118,7 @@
     },
     "file-entry-cache": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
@@ -3151,7 +3151,7 @@
     },
     "filename-regex": {
       "version": "2.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/filename-regex/-/filename-regex-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
     },
@@ -3212,7 +3212,7 @@
     },
     "find-cache-dir": {
       "version": "0.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
       "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
       "dev": true,
       "requires": {
@@ -3223,7 +3223,7 @@
     },
     "find-up": {
       "version": "1.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/find-up/-/find-up-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
@@ -3233,7 +3233,7 @@
     },
     "flat-cache": {
       "version": "1.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/flat-cache/-/flat-cache-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
@@ -3245,7 +3245,7 @@
     },
     "flatten": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/flatten/-/flatten-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
     },
@@ -3271,7 +3271,7 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
@@ -3286,13 +3286,13 @@
     },
     "foreach": {
       "version": "2.0.5",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/foreach/-/foreach-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
@@ -3309,13 +3309,13 @@
     },
     "forwarded": {
       "version": "0.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/forwarded/-/forwarded-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
@@ -3324,13 +3324,13 @@
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
@@ -4240,7 +4240,7 @@
     },
     "fstream": {
       "version": "1.0.11",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/fstream/-/fstream-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
@@ -4263,7 +4263,7 @@
     },
     "gauge": {
       "version": "2.7.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/gauge/-/gauge-2.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
@@ -4279,7 +4279,7 @@
     },
     "gaze": {
       "version": "1.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/gaze/-/gaze-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
       "dev": true,
       "requires": {
@@ -4288,13 +4288,13 @@
     },
     "generate-function": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/generate-function/-/generate-function-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
       "dev": true
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
@@ -4303,13 +4303,13 @@
     },
     "get-caller-file": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/get-stdin/-/get-stdin-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
@@ -4321,13 +4321,13 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -4350,7 +4350,7 @@
     },
     "glob-base": {
       "version": "0.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/glob-base/-/glob-base-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
@@ -4360,7 +4360,7 @@
     },
     "glob-parent": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/glob-parent/-/glob-parent-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
@@ -4375,7 +4375,7 @@
     },
     "globby": {
       "version": "5.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/globby/-/globby-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
@@ -4389,7 +4389,7 @@
     },
     "globule": {
       "version": "1.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/globule/-/globule-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
       "dev": true,
       "requires": {
@@ -4400,7 +4400,7 @@
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
@@ -4465,13 +4465,13 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
       "version": "5.0.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/har-validator/-/har-validator-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
@@ -4481,7 +4481,7 @@
       "dependencies": {
         "ajv": {
           "version": "5.5.2",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/ajv/-/ajv-5.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
@@ -4495,7 +4495,7 @@
     },
     "has": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/has/-/has-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
@@ -4504,7 +4504,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -4513,19 +4513,19 @@
     },
     "has-flag": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/has-flag/-/has-flag-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/has-unicode/-/has-unicode-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
@@ -4536,7 +4536,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
@@ -4546,7 +4546,7 @@
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -4555,7 +4555,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
@@ -4566,7 +4566,7 @@
         },
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
@@ -4608,7 +4608,7 @@
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
@@ -4625,7 +4625,7 @@
     },
     "home-or-tmp": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
@@ -4653,7 +4653,7 @@
     },
     "html-comment-regex": {
       "version": "1.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
       "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4=",
       "dev": true
     },
@@ -4752,7 +4752,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
@@ -4763,7 +4763,7 @@
     },
     "https-browserify": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/https-browserify/-/https-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
@@ -4775,7 +4775,7 @@
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
       "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
       "dev": true
     },
@@ -4823,19 +4823,19 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "in-publish": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/in-publish/-/in-publish-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
       "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
     },
     "indent-string": {
       "version": "2.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/indent-string/-/indent-string-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
@@ -4844,19 +4844,19 @@
     },
     "indexes-of": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/indexes-of/-/indexes-of-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
     "indexof": {
       "version": "0.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/indexof/-/indexof-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -4866,13 +4866,13 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/inherits/-/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "inquirer": {
       "version": "0.12.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/inquirer/-/inquirer-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
@@ -4902,7 +4902,7 @@
     },
     "interpret": {
       "version": "1.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/interpret/-/interpret-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
@@ -4917,7 +4917,7 @@
     },
     "invert-kv": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/invert-kv/-/invert-kv-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
@@ -4935,7 +4935,7 @@
     },
     "is-absolute-url": {
       "version": "2.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
       "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
       "dev": true
     },
@@ -4958,13 +4958,13 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
@@ -4979,7 +4979,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -4988,7 +4988,7 @@
     },
     "is-callable": {
       "version": "1.1.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-callable/-/is-callable-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
       "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
       "dev": true
     },
@@ -5020,7 +5020,7 @@
     },
     "is-date-object": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-date-object/-/is-date-object-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
@@ -5045,13 +5045,13 @@
     },
     "is-dotfile": {
       "version": "1.0.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
@@ -5060,19 +5060,19 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-extglob/-/is-extglob-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
       "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-finite/-/is-finite-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
@@ -5081,7 +5081,7 @@
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
@@ -5096,7 +5096,7 @@
     },
     "is-glob": {
       "version": "2.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-glob/-/is-glob-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
@@ -5124,7 +5124,7 @@
     },
     "is-number": {
       "version": "2.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-number/-/is-number-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
@@ -5150,7 +5150,7 @@
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
@@ -5165,7 +5165,7 @@
     },
     "is-path-inside": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
@@ -5174,7 +5174,7 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
@@ -5189,25 +5189,25 @@
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
       "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-primitive/-/is-primitive-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
     "is-property": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-property/-/is-property-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-regex/-/is-regex-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
@@ -5228,7 +5228,7 @@
     },
     "is-svg": {
       "version": "2.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-svg/-/is-svg-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
       "dev": true,
       "requires": {
@@ -5237,18 +5237,18 @@
     },
     "is-symbol": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-symbol/-/is-symbol-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
       "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-utf8/-/is-utf8-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
@@ -5266,13 +5266,13 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
@@ -5284,7 +5284,7 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
@@ -6402,13 +6402,13 @@
     },
     "js-tokens": {
       "version": "3.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/js-tokens/-/js-tokens-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
       "version": "3.7.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/js-yaml/-/js-yaml-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "dev": true,
       "requires": {
@@ -6418,7 +6418,7 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
@@ -6459,7 +6459,7 @@
     },
     "jsesc": {
       "version": "1.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/jsesc/-/jsesc-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
@@ -6471,19 +6471,19 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
@@ -6492,7 +6492,7 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
@@ -6504,25 +6504,25 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
     "jsonify": {
       "version": "0.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/jsonify/-/jsonify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsonpointer": {
       "version": "4.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
@@ -6540,7 +6540,7 @@
     },
     "kind-of": {
       "version": "3.2.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/kind-of/-/kind-of-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
@@ -6565,7 +6565,7 @@
     },
     "lcid": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/lcid/-/lcid-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
@@ -6586,7 +6586,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
@@ -6596,7 +6596,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -6609,7 +6609,7 @@
       "dependencies": {
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/strip-bom/-/strip-bom-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
@@ -6620,7 +6620,7 @@
     },
     "loader-fs-cache": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz",
       "integrity": "sha1-VuC/CL2XCLJqdltoUJhAyN7J/bw=",
       "dev": true,
       "requires": {
@@ -6630,13 +6630,13 @@
     },
     "loader-runner": {
       "version": "2.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/loader-runner/-/loader-runner-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
       "integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
       "dev": true
     },
     "loader-utils": {
       "version": "0.2.17",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/loader-utils/-/loader-utils-0.2.17.tgz",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "dev": true,
       "requires": {
@@ -6648,7 +6648,7 @@
     },
     "locate-path": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/locate-path/-/locate-path-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
@@ -6658,7 +6658,7 @@
       "dependencies": {
         "path-exists": {
           "version": "3.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/path-exists/-/path-exists-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
@@ -6672,25 +6672,25 @@
     },
     "lodash.assign": {
       "version": "4.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
@@ -6708,13 +6708,13 @@
     },
     "lodash.tail": {
       "version": "4.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/lodash.tail/-/lodash.tail-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
       "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
       "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
@@ -6726,13 +6726,13 @@
     },
     "longest": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/longest/-/longest-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/loose-envify/-/loose-envify-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
@@ -6741,7 +6741,7 @@
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
@@ -6761,7 +6761,7 @@
     },
     "macaddress": {
       "version": "0.2.8",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/macaddress/-/macaddress-0.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
       "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
       "dev": true
     },
@@ -6776,19 +6776,19 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
     "map-obj": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/map-obj/-/map-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
@@ -6797,13 +6797,13 @@
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
       "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
       "dev": true
     },
     "md5.js": {
       "version": "1.3.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/md5.js/-/md5.js-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
@@ -6831,7 +6831,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -6846,7 +6846,7 @@
     },
     "memory-fs": {
       "version": "0.4.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/memory-fs/-/memory-fs-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
@@ -6856,7 +6856,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -6874,7 +6874,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -6888,7 +6888,7 @@
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
@@ -6903,13 +6903,13 @@
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
     "micromatch": {
       "version": "2.3.11",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/micromatch/-/micromatch-2.3.11.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
@@ -6971,7 +6971,7 @@
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
@@ -6986,7 +6986,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -7013,7 +7013,7 @@
     },
     "mixin-object": {
       "version": "2.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/mixin-object/-/mixin-object-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
       "dev": true,
       "requires": {
@@ -7023,7 +7023,7 @@
       "dependencies": {
         "for-in": {
           "version": "0.1.8",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/for-in/-/for-in-0.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
           "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
           "dev": true
         }
@@ -7031,7 +7031,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -7040,7 +7040,7 @@
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multicast-dns": {
@@ -7061,7 +7061,7 @@
     },
     "mute-stream": {
       "version": "0.0.5",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/mute-stream/-/mute-stream-0.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
@@ -7141,13 +7141,13 @@
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/negotiator/-/negotiator-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
@@ -7159,7 +7159,7 @@
     },
     "node-gyp": {
       "version": "3.6.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/node-gyp/-/node-gyp-3.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "requires": {
@@ -7180,7 +7180,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -7237,7 +7237,7 @@
     },
     "node-sass": {
       "version": "4.5.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/node-sass/-/node-sass-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.0.tgz",
       "integrity": "sha1-Uy43utDOWHNIyDFTXbyY6kKJUIs=",
       "dev": true,
       "requires": {
@@ -7263,7 +7263,7 @@
     },
     "nopt": {
       "version": "3.0.6",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/nopt/-/nopt-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
@@ -7284,7 +7284,7 @@
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/normalize-path/-/normalize-path-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
@@ -7293,13 +7293,13 @@
     },
     "normalize-range": {
       "version": "0.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/normalize-range/-/normalize-range-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
     "normalize-url": {
       "version": "1.9.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/normalize-url/-/normalize-url-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
       "dev": true,
       "requires": {
@@ -7332,13 +7332,13 @@
     },
     "num2fraction": {
       "version": "1.2.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/num2fraction/-/num2fraction-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
@@ -7350,19 +7350,19 @@
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
@@ -7373,7 +7373,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -7427,13 +7427,13 @@
     },
     "object-keys": {
       "version": "1.0.11",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/object-keys/-/object-keys-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
       "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
@@ -7452,7 +7452,7 @@
     },
     "object.omit": {
       "version": "2.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/object.omit/-/object.omit-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
@@ -7473,7 +7473,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
@@ -7488,7 +7488,7 @@
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "dev": true,
       "requires": {
@@ -7503,7 +7503,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -7512,7 +7512,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -7589,7 +7589,7 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/optionator/-/optionator-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
@@ -7624,13 +7624,13 @@
     },
     "os-browserify": {
       "version": "0.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/os-browserify/-/os-browserify-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -7645,7 +7645,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -7676,7 +7676,7 @@
     },
     "p-locate": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/p-locate/-/p-locate-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
@@ -7691,7 +7691,7 @@
     },
     "p-try": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/p-try/-/p-try-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
@@ -7716,7 +7716,7 @@
     },
     "parse-glob": {
       "version": "3.0.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/parse-glob/-/parse-glob-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
@@ -7728,7 +7728,7 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/parse-json/-/parse-json-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
@@ -7743,19 +7743,19 @@
     },
     "parseurl": {
       "version": "1.3.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/parseurl/-/parseurl-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
       "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
     "path-browserify": {
       "version": "0.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/path-browserify/-/path-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
       "dev": true
     },
@@ -7767,7 +7767,7 @@
     },
     "path-exists": {
       "version": "2.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/path-exists/-/path-exists-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
@@ -7776,13 +7776,13 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
@@ -7794,19 +7794,19 @@
     },
     "path-parse": {
       "version": "1.0.5",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/path-parse/-/path-parse-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
     "path-type": {
       "version": "1.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/path-type/-/path-type-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
@@ -7830,25 +7830,25 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
@@ -7857,7 +7857,7 @@
     },
     "pkg-dir": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
@@ -7866,7 +7866,7 @@
     },
     "pluralize": {
       "version": "1.2.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/pluralize/-/pluralize-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
@@ -7897,7 +7897,7 @@
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
@@ -7926,7 +7926,7 @@
     },
     "postcss-calc": {
       "version": "5.3.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-calc/-/postcss-calc-5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
       "dev": true,
       "requires": {
@@ -7937,7 +7937,7 @@
     },
     "postcss-colormin": {
       "version": "2.2.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
       "dev": true,
       "requires": {
@@ -7948,7 +7948,7 @@
     },
     "postcss-convert-values": {
       "version": "2.6.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
       "dev": true,
       "requires": {
@@ -7958,7 +7958,7 @@
     },
     "postcss-discard-comments": {
       "version": "2.0.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
       "dev": true,
       "requires": {
@@ -7967,7 +7967,7 @@
     },
     "postcss-discard-duplicates": {
       "version": "2.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
       "dev": true,
       "requires": {
@@ -7976,7 +7976,7 @@
     },
     "postcss-discard-empty": {
       "version": "2.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
       "dev": true,
       "requires": {
@@ -7985,7 +7985,7 @@
     },
     "postcss-discard-overridden": {
       "version": "0.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
       "dev": true,
       "requires": {
@@ -7994,7 +7994,7 @@
     },
     "postcss-discard-unused": {
       "version": "2.2.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "dev": true,
       "requires": {
@@ -8004,7 +8004,7 @@
     },
     "postcss-filter-plugins": {
       "version": "2.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
       "dev": true,
       "requires": {
@@ -8014,7 +8014,7 @@
     },
     "postcss-merge-idents": {
       "version": "2.1.7",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "dev": true,
       "requires": {
@@ -8025,7 +8025,7 @@
     },
     "postcss-merge-longhand": {
       "version": "2.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
       "dev": true,
       "requires": {
@@ -8034,7 +8034,7 @@
     },
     "postcss-merge-rules": {
       "version": "2.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
       "dev": true,
       "requires": {
@@ -8047,7 +8047,7 @@
       "dependencies": {
         "browserslist": {
           "version": "1.7.7",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/browserslist/-/browserslist-1.7.7.tgz",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
@@ -8059,13 +8059,13 @@
     },
     "postcss-message-helpers": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
       "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
       "dev": true
     },
     "postcss-minify-font-values": {
       "version": "1.0.5",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
       "dev": true,
       "requires": {
@@ -8076,7 +8076,7 @@
     },
     "postcss-minify-gradients": {
       "version": "1.0.5",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
       "dev": true,
       "requires": {
@@ -8086,7 +8086,7 @@
     },
     "postcss-minify-params": {
       "version": "1.2.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
       "dev": true,
       "requires": {
@@ -8098,7 +8098,7 @@
     },
     "postcss-minify-selectors": {
       "version": "2.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
       "dev": true,
       "requires": {
@@ -8110,7 +8110,7 @@
     },
     "postcss-modules-extract-imports": {
       "version": "1.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
@@ -8139,7 +8139,7 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
@@ -8173,7 +8173,7 @@
     },
     "postcss-modules-local-by-default": {
       "version": "1.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "dev": true,
       "requires": {
@@ -8203,7 +8203,7 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
@@ -8237,7 +8237,7 @@
     },
     "postcss-modules-scope": {
       "version": "1.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "dev": true,
       "requires": {
@@ -8267,7 +8267,7 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
@@ -8301,7 +8301,7 @@
     },
     "postcss-modules-values": {
       "version": "1.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "dev": true,
       "requires": {
@@ -8331,7 +8331,7 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
@@ -8365,7 +8365,7 @@
     },
     "postcss-normalize-charset": {
       "version": "1.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
       "dev": true,
       "requires": {
@@ -8374,7 +8374,7 @@
     },
     "postcss-normalize-url": {
       "version": "3.0.8",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
       "dev": true,
       "requires": {
@@ -8386,7 +8386,7 @@
     },
     "postcss-ordered-values": {
       "version": "2.2.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
       "dev": true,
       "requires": {
@@ -8396,7 +8396,7 @@
     },
     "postcss-reduce-idents": {
       "version": "2.4.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "dev": true,
       "requires": {
@@ -8406,7 +8406,7 @@
     },
     "postcss-reduce-initial": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
       "dev": true,
       "requires": {
@@ -8415,7 +8415,7 @@
     },
     "postcss-reduce-transforms": {
       "version": "1.0.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "dev": true,
       "requires": {
@@ -8426,7 +8426,7 @@
     },
     "postcss-selector-parser": {
       "version": "2.2.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
       "dev": true,
       "requires": {
@@ -8437,7 +8437,7 @@
     },
     "postcss-svgo": {
       "version": "2.1.6",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
       "dev": true,
       "requires": {
@@ -8449,7 +8449,7 @@
     },
     "postcss-unique-selectors": {
       "version": "2.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
       "dev": true,
       "requires": {
@@ -8460,13 +8460,13 @@
     },
     "postcss-value-parser": {
       "version": "3.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
       "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
       "dev": true
     },
     "postcss-zindex": {
       "version": "2.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "dev": true,
       "requires": {
@@ -8477,19 +8477,19 @@
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/prepend-http/-/prepend-http-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
     "preserve": {
       "version": "0.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/preserve/-/preserve-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
@@ -8528,7 +8528,7 @@
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/process/-/process-0.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
@@ -8540,7 +8540,7 @@
     },
     "progress": {
       "version": "1.1.8",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/progress/-/progress-1.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
@@ -8556,13 +8556,13 @@
     },
     "prr": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/prr/-/prr-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
@@ -8587,7 +8587,7 @@
     },
     "q": {
       "version": "1.5.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/q/-/q-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
@@ -8599,7 +8599,7 @@
     },
     "query-string": {
       "version": "4.3.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/query-string/-/query-string-4.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "dev": true,
       "requires": {
@@ -8609,13 +8609,13 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
@@ -8687,13 +8687,13 @@
     },
     "range-parser": {
       "version": "1.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/range-parser/-/range-parser-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
     },
     "raw-body": {
       "version": "2.3.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/raw-body/-/raw-body-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
       "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
       "dev": true,
       "requires": {
@@ -8705,7 +8705,7 @@
     },
     "read-pkg": {
       "version": "1.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/read-pkg/-/read-pkg-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
@@ -8716,7 +8716,7 @@
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
@@ -8741,7 +8741,7 @@
     },
     "readdirp": {
       "version": "2.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/readdirp/-/readdirp-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
@@ -8753,7 +8753,7 @@
     },
     "readline2": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/readline2/-/readline2-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
@@ -8773,7 +8773,7 @@
     },
     "rechoir": {
       "version": "0.6.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/rechoir/-/rechoir-0.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
@@ -8782,7 +8782,7 @@
     },
     "redent": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/redent/-/redent-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
@@ -8792,7 +8792,7 @@
     },
     "reduce-css-calc": {
       "version": "1.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
       "requires": {
@@ -8803,7 +8803,7 @@
       "dependencies": {
         "balanced-match": {
           "version": "0.4.2",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/balanced-match/-/balanced-match-0.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         }
@@ -8811,7 +8811,7 @@
     },
     "reduce-function-call": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "dev": true,
       "requires": {
@@ -8820,7 +8820,7 @@
       "dependencies": {
         "balanced-match": {
           "version": "0.4.2",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/balanced-match/-/balanced-match-0.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         }
@@ -8869,7 +8869,7 @@
     },
     "regexpu-core": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
@@ -8880,13 +8880,13 @@
     },
     "regjsgen": {
       "version": "0.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/regjsgen/-/regjsgen-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
       "dev": true
     },
     "regjsparser": {
       "version": "0.1.5",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/regjsparser/-/regjsparser-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
@@ -8895,7 +8895,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -8903,25 +8903,25 @@
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/repeat-element/-/repeat-element-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/repeating/-/repeating-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
@@ -8980,19 +8980,19 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -9017,7 +9017,7 @@
     },
     "resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
@@ -9026,7 +9026,7 @@
       "dependencies": {
         "resolve-from": {
           "version": "3.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/resolve-from/-/resolve-from-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
@@ -9034,19 +9034,19 @@
     },
     "resolve-from": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/resolve-from/-/resolve-from-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "restore-cursor": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
@@ -9062,7 +9062,7 @@
     },
     "right-align": {
       "version": "0.1.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/right-align/-/right-align-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
@@ -9090,7 +9090,7 @@
     },
     "run-async": {
       "version": "0.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/run-async/-/run-async-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
@@ -9099,7 +9099,7 @@
     },
     "rx-lite": {
       "version": "3.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/rx-lite/-/rx-lite-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
       "dev": true
     },
@@ -9472,7 +9472,7 @@
     },
     "sass-graph": {
       "version": "2.2.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/sass-graph/-/sass-graph-2.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
@@ -9552,7 +9552,7 @@
     },
     "scss-tokenizer": {
       "version": "0.2.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
@@ -9562,7 +9562,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
@@ -9665,7 +9665,7 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
@@ -9680,7 +9680,7 @@
     },
     "set-immediate-shim": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
@@ -9698,7 +9698,7 @@
     },
     "setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/setimmediate/-/setimmediate-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
     },
@@ -9758,7 +9758,7 @@
     },
     "shelljs": {
       "version": "0.7.8",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/shelljs/-/shelljs-0.7.8.tgz",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
@@ -9775,19 +9775,19 @@
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "slash": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/slash/-/slash-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
     },
@@ -9941,7 +9941,7 @@
     },
     "sort-keys": {
       "version": "1.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/sort-keys/-/sort-keys-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
@@ -9950,13 +9950,13 @@
     },
     "source-list-map": {
       "version": "0.1.8",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/source-list-map/-/source-list-map-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
       "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
       "dev": true
     },
     "source-map": {
       "version": "0.5.7",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
@@ -9984,7 +9984,7 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
@@ -10070,7 +10070,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -10098,7 +10098,7 @@
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
@@ -10108,7 +10108,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -10182,7 +10182,7 @@
     },
     "stdout-stream": {
       "version": "1.4.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/stdout-stream/-/stdout-stream-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true,
       "requires": {
@@ -10197,7 +10197,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
@@ -10220,7 +10220,7 @@
     },
     "strict-uri-encode": {
       "version": "1.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
@@ -10253,7 +10253,7 @@
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
@@ -10279,7 +10279,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -10288,7 +10288,7 @@
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
@@ -10300,7 +10300,7 @@
     },
     "strip-indent": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/strip-indent/-/strip-indent-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
@@ -10309,13 +10309,13 @@
     },
     "strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "style-loader": {
       "version": "0.14.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/style-loader/-/style-loader-0.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.14.1.tgz",
       "integrity": "sha1-J7m2yYIq34xHSOAqHvriKUBdeaU=",
       "dev": true,
       "requires": {
@@ -10324,7 +10324,7 @@
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/loader-utils/-/loader-utils-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
@@ -10337,7 +10337,7 @@
     },
     "supports-color": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/supports-color/-/supports-color-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
@@ -10366,7 +10366,7 @@
     },
     "svgo": {
       "version": "0.7.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/svgo/-/svgo-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "dev": true,
       "requires": {
@@ -10387,7 +10387,7 @@
     },
     "table": {
       "version": "3.8.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/table/-/table-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
@@ -10401,13 +10401,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -10423,7 +10423,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -10434,13 +10434,13 @@
     },
     "tapable": {
       "version": "0.2.8",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/tapable/-/tapable-0.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
       "dev": true
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/tar/-/tar-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
@@ -10784,7 +10784,7 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
@@ -10796,7 +10796,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -10829,19 +10829,19 @@
     },
     "to-arraybuffer": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
@@ -10929,7 +10929,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
@@ -10939,7 +10939,7 @@
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -10976,13 +10976,13 @@
     },
     "trim-newlines": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/trim-right/-/trim-right-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
@@ -10994,13 +10994,13 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
@@ -11009,14 +11009,14 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -11035,7 +11035,7 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
@@ -11049,7 +11049,7 @@
     },
     "uglify-js": {
       "version": "2.8.29",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/uglify-js/-/uglify-js-2.8.29.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "requires": {
@@ -11083,7 +11083,7 @@
         },
         "yargs": {
           "version": "3.10.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/yargs/-/yargs-3.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
@@ -11097,7 +11097,7 @@
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
@@ -11115,7 +11115,7 @@
     },
     "union-value": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/union-value/-/union-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
@@ -11127,7 +11127,7 @@
       "dependencies": {
         "set-value": {
           "version": "0.4.3",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/set-value/-/set-value-0.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
@@ -11141,13 +11141,13 @@
     },
     "uniq": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/uniq/-/uniq-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
     "uniqid": {
       "version": "4.1.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/uniqid/-/uniqid-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
       "dev": true,
       "requires": {
@@ -11156,19 +11156,19 @@
     },
     "uniqs": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/uniqs/-/uniqs-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
@@ -11178,7 +11178,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
@@ -11189,7 +11189,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
               "requires": {
@@ -11200,7 +11200,7 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         }
@@ -11231,13 +11231,13 @@
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/url/-/url-0.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
       "requires": {
@@ -11247,7 +11247,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/punycode/-/punycode-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
@@ -11361,7 +11361,7 @@
     },
     "user-home": {
       "version": "2.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/user-home/-/user-home-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
@@ -11370,7 +11370,7 @@
     },
     "util": {
       "version": "0.10.3",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/util/-/util-0.10.3.tgz",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
       "requires": {
@@ -11379,7 +11379,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/inherits/-/inherits-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
           "dev": true
         }
@@ -11387,7 +11387,7 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
@@ -11403,7 +11403,7 @@
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
@@ -11425,7 +11425,7 @@
     },
     "vary": {
       "version": "1.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
@@ -11437,7 +11437,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
@@ -11448,7 +11448,7 @@
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true,
       "requires": {
@@ -12348,7 +12348,7 @@
     },
     "websocket": {
       "version": "1.0.24",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/websocket/-/websocket-1.0.24.tgz",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.24.tgz",
       "integrity": "sha1-dJA+dfJUW2suHeFCW8HJBZF6GJA=",
       "requires": {
         "debug": "2.6.9",
@@ -12395,7 +12395,7 @@
     },
     "whet.extend": {
       "version": "0.9.9",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/whet.extend/-/whet.extend-0.9.9.tgz",
+      "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
       "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
       "dev": true
     },
@@ -12425,19 +12425,19 @@
     },
     "window-size": {
       "version": "0.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/window-size/-/window-size-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -12447,13 +12447,13 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write": {
       "version": "0.2.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/write/-/write-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
@@ -12483,7 +12483,7 @@
     },
     "xhr2": {
       "version": "0.1.4",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/xhr2/-/xhr2-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
       "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
     },
     "xml-name-validator": {
@@ -12494,24 +12494,24 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/xtend/-/xtend-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "y18n": {
       "version": "3.2.1",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/y18n/-/y18n-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yaeti": {
       "version": "0.0.6",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/yaeti/-/yaeti-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
       "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",
-      "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/yallist/-/yallist-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1677,7 +1677,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -2799,7 +2799,7 @@
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/loader-utils/-/loader-utils-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
@@ -4803,7 +4803,7 @@
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/find-up/-/find-up-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
@@ -4812,7 +4812,7 @@
         },
         "pkg-dir": {
           "version": "2.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
           "dev": true,
           "requires": {
@@ -7915,7 +7915,7 @@
       "dependencies": {
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
@@ -9497,7 +9497,7 @@
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/loader-utils/-/loader-utils-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
           "dev": true,
           "requires": {
@@ -9508,7 +9508,7 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -9809,7 +9809,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "https://onshift.jfrog.io/onshift/api/npm/npm-main/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {

--- a/src/js/elements/list-board.js
+++ b/src/js/elements/list-board.js
@@ -197,14 +197,16 @@ class ListBoard extends Element {
         let item = this.createDiv();
         this._setClass(item, [className.ITEM]);
         let itemImg = this.createDiv();
-        this._setClass(itemImg, [className.IMAGE]);
-        this._setBackgroundImage(itemImg, DEFAULT_PROFILE_PIC);
-        item.appendChild(itemImg);
 
         let itemContent = this.createDiv();
-        this._setClass(itemContent, [className.CONTENT]);
 
+        this._setClass(itemContent, [className.CONTENT]);
+        this._setClass(itemImg, [className.IMAGE]);
+
+        this._setBackgroundImage(itemImg, DEFAULT_PROFILE_PIC);
         let contentTop = this.createDiv();
+        itemContent.appendChild(itemImg);
+
         this._setClass(contentTop, [className.CONTENT_TOP]);
         let contentTitle = this.createDiv();
         this._setClass(contentTitle, [className.TITLE]);

--- a/src/js/widget.js
+++ b/src/js/widget.js
@@ -443,7 +443,7 @@ class SBWidget {
                 for (let i = 0; i < this.searchedUserList.length; i++) {
                     let user = this.searchedUserList[i];
                     if (!activeUserIds.includes(user.userId)) {
-                        renderUser(user, false)
+                        renderUser(user, false);
                     }
                 }
             }

--- a/src/scss/reset.scss
+++ b/src/scss/reset.scss
@@ -3,6 +3,7 @@ html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockq
   padding: 0;
   border: 0;
   vertical-align: baseline;
+  box-sizing: border-box;
 }
 
 /* HTML5 display-role reset for older browsers */

--- a/src/scss/widget.scss
+++ b/src/scss/widget.scss
@@ -759,7 +759,7 @@
       }
 
       .message-content {
-        width: calc(100% - 16px);
+        width: 100%;
         max-height: 92%;
         height: 92%;
         min-height: 240px;
@@ -992,6 +992,7 @@
         .text {
           background: $color-purple;
           color: $color-white;
+          margin-right: 7px;
         }
         .image {
           display: inline-block;

--- a/src/scss/widget.scss
+++ b/src/scss/widget.scss
@@ -1062,8 +1062,7 @@
 
           & > li {
             display: inline-table;
-            width: calc(100% - 24px);
-            height: calc(44px - 11px);
+            width: 95%;
             background: $color-white;
             padding: 0 12px;
             cursor: pointer;

--- a/src/scss/widget.scss
+++ b/src/scss/widget.scss
@@ -50,6 +50,7 @@
   }
 
   .ic-minimize {
+    // todo mobile styling here
     margin-right: 4%;
     @include icon($icon-minimize);
     @include hover {
@@ -68,6 +69,7 @@
   }
 
   .ic-new-chat {
+    // todo mobile styling here
     margin-right: 4%;
     @include icon($icon-new-chat);
     @include hover {
@@ -289,8 +291,7 @@
               bottom: 100%;
               left: calc(50% + 21px);
               margin-left: -5px;
-              border-width: 7px;
-              border-style: solid;
+              border: 7px solid;
               border-color: transparent transparent $color-white transparent;
             }
           }
@@ -380,7 +381,6 @@
         li {
           width: calc(100% - 24px);
           height: 48px;
-          padding: 0 12px;
           background-color: $color-white;
           cursor: pointer;
           @include hover {
@@ -401,6 +401,7 @@
         .image {
           float: left;
           width: 36px;
+          margin-right: 4%;
           height: 100%;
           @include icon($icon-channel-1);
         }
@@ -419,7 +420,7 @@
             padding: 0;
             float: left;
             width: 125px;
-            height: 18px;
+            height: 100%;
             font-size: 14px;
             color: $color-content-text;
             line-height: 18px;
@@ -431,7 +432,7 @@
           time {
             float: right;
             font-size: 12px;
-            line-height: 18px;
+            height: 100%;
             color: $color-gray-light;
           }
         }

--- a/src/scss/widget.scss
+++ b/src/scss/widget.scss
@@ -1198,6 +1198,7 @@
         top: 42%;
         margin-right: 2%;
         width: 30%;
+        text-align: center;
         @media #{$mobile} {
           top: 22%;
           margin-right: 10%;

--- a/src/scss/widget.scss
+++ b/src/scss/widget.scss
@@ -122,7 +122,6 @@
     z-index: 1;
     font-size: 12px;
     color: $color-white;
-    padding: 0 12px;
     height: 32px;
     line-height: 32px;
 
@@ -258,10 +257,10 @@
 
         .tooltip {
           @extend .tooltip;
-          width: 74px;
+          width: 79px;
           position: absolute;
           top: -37px;
-          left: -37px;
+          left: -29px;
         }
 
         .option-menu {
@@ -640,10 +639,10 @@
       .btn.ic-invite {
         .tooltip {
           @extend .tooltip;
-          width: 78px;
+          width: 86px;
           position: absolute;
           top: -37px;
-          left: -39px;
+          left: -31px;
         }
       }
     }
@@ -680,7 +679,7 @@
             cursor: pointer;
           }
         }
-        @include user-search(100%, '../assets/mag-glass.svg', '../assets/user-search-clear.svg');
+        @include user-search(90%, '../assets/mag-glass.svg', '../assets/user-search-clear.svg');
         .user-item {
           width: 100%;
           height: 100%;

--- a/src/scss/widget.scss
+++ b/src/scss/widget.scss
@@ -378,7 +378,7 @@
         padding: 0;
 
         li {
-          width: 93%;
+          width: 95%;
           height: 48px;
           background-color: $color-white;
           cursor: pointer;
@@ -441,7 +441,7 @@
 
           .last-message {
             float: left;
-            width: 170px;
+            width: 50%;
             height: 18px;
             font-size: 13px;
             color: $color-gray-light;
@@ -584,15 +584,15 @@
     }
 
     .top {
-      width: calc(100% - 24px);
+      width: 100%;
       height: 35px;
-      padding: 0 12px;
       background-color: $color-gray-lightest;
       border-bottom: 1px solid $color-list-border;
       @include box-shadow(0 1px 1px -2px rgba(0, 0, 0, 0.20));
 
       .title {
         float: left;
+        padding-left: 4%;
         max-width: 123px;
         font-size: 13px;
         color: $color-content-text;
@@ -624,6 +624,7 @@
         width: 24px;
         height: 26px;
         position: relative;
+        margin-right: 3%;
         top: 50%;
         cursor: pointer;
         @include transform-translate(0, -50%);
@@ -673,7 +674,7 @@
           list-style-type: none;
 
           li {
-            width: calc(100% - 24px);
+            width: 100%;
             height: 44px;
             padding: 0 12px;
             cursor: pointer;
@@ -722,10 +723,7 @@
       }
 
       .content-bottom {
-        width: 91%;
-        @media #{$mobile} {
-          width: 97%;
-        }
+        width: 100%;
         height: calc(52px - 7px);
         padding: 4px 0 0 9px;
         background-color: $color-gray-lightest;

--- a/src/scss/widget.scss
+++ b/src/scss/widget.scss
@@ -70,7 +70,7 @@
 
   .ic-new-chat {
     // todo mobile styling here
-    margin-right: 4%;
+    margin-right: 3%;
     @include icon($icon-new-chat);
     @include hover {
       @include icon($icon-new-chat-hover);
@@ -680,10 +680,10 @@
             cursor: pointer;
           }
         }
-        @include user-search(60%, '../assets/mag-glass.svg', '../assets/user-search-clear.svg');
+        @include user-search(100%, '../assets/mag-glass.svg', '../assets/user-search-clear.svg');
         .user-item {
           width: 100%;
-          height: calc(100% - 12px - 1px);
+          height: 100%;
           padding: 6px 0;
           border-bottom: 1px solid $color-list-border;
 
@@ -734,15 +734,13 @@
           @extend .sb-common-btn;
           display: inline-block;
           width: 33%;
-          height: 56%;
-          @media #{$mobile} {
-            height: 61%;
-          }
+          height: 70%;
           padding: 0 12px;
           text-align: center;
           line-height: 26px;
           font-size: 13px;
           letter-spacing: 0.85px;
+          margin-top: 0.5%;
 
           .sb-spinner {
             div {
@@ -1198,10 +1196,14 @@
         float: right;
         position: relative;
         top: 42%;
+        margin-right: 2%;
+        width: 30%;
         @media #{$mobile} {
           top: 22%;
+          margin-right: 10%;
+          padding: 0 7%;
+          width: 25%;
         }
-        width: 41px;
         height: 24px;
         font-size: 14px;
         line-height: 24px;

--- a/src/scss/widget.scss
+++ b/src/scss/widget.scss
@@ -50,6 +50,7 @@
   }
 
   .ic-minimize {
+    margin-right: 4%;
     @include icon($icon-minimize);
     @include hover {
       @include icon($icon-minimize-hover);
@@ -67,6 +68,7 @@
   }
 
   .ic-new-chat {
+    margin-right: 4%;
     @include icon($icon-new-chat);
     @include hover {
       @include icon($icon-new-chat-hover);
@@ -218,16 +220,16 @@
     @include box-shadow(0 3px 6px rgba(0, 0, 0, 0.3));
 
     .board-top {
-      width: calc(100% - 24px);
+      width: 100%;
       height: 36px;
       background-color: $color-purple;
-      padding: 0 12px;
       border-bottom: 1px solid $color-list-top-border;
 
       .title {
         display: inline-block;
         float: left;
         font-size: 16px;
+        padding-left: 4%;
         color: $color-list-top-title;
         letter-spacing: 0.85px;
         line-height: 36px;

--- a/src/scss/widget.scss
+++ b/src/scss/widget.scss
@@ -376,10 +376,9 @@
         width: 100%;
         margin: 0;
         padding: 0;
-        list-style-type: none;
 
         li {
-          width: calc(100% - 24px);
+          width: 93%;
           height: 48px;
           background-color: $color-white;
           cursor: pointer;
@@ -392,8 +391,8 @@
 
           .item {
             width: 100%;
-            height: calc(100% - 12px - 1px);
-            padding: 6px 0;
+            height: 100%;
+            margin: 2% 0;
             border-bottom: 1px solid $color-list-border;
           }
         }
@@ -401,15 +400,15 @@
         .image {
           float: left;
           width: 36px;
-          margin-right: 4%;
+          margin: 0 4%;
           height: 100%;
           @include icon($icon-channel-1);
         }
 
         .content {
           float: right;
-          width: calc(100% - 36px - 8px);
-          height: 100%;
+          width: 100%;
+          height: 85%;
           margin-left: 8px;
         }
         .content-top {

--- a/src/scss/widget.scss
+++ b/src/scss/widget.scss
@@ -473,12 +473,9 @@
           }
           & > .new-chat-btn {
             @extend .sb-common-btn;
-            display: block;
             margin: 0 auto;
-            width: 48px;
-            height: 30px;
+            width: 33%;
             line-height: 30px;
-            padding: 0 16px;
           }
         }
       }


### PR DESCRIPTION
# Things Done
- added `box-sizing: border-box` to `reset.scss`
  - with this, we have parity with how engage and kangaroo apply stylings
  - for an explanation [click here](https://www.w3schools.com/cssref/css3_pr_box-sizing.asp)
    - essentially we are including margins and padding when calculating the width of boxes and it appears that kangaroo has this on all their stylings
    - a good idea anyway, considering something with a width of `100%` should _never be bigger than its parent dammit_ and that's something the SB devs did a lot of
    - actually simplifies styling
- with this is mind, fixed all the strange styling
- some HTML manipulation

# How to Test
- make sure the widget looks good (and the same) in
  - engage
  - kangaroo
  - standalone mode

# Notes
- once this is merged (the sooner the better) we need to bump the widget version to 0.8.1 in order to make it look like we know what we are doing to the engage and kangaroo teams :)